### PR TITLE
Resolve relative source files from project root

### DIFF
--- a/lib/coverage-container.js
+++ b/lib/coverage-container.js
@@ -1,5 +1,6 @@
 'use babel'
 
+import path from 'path'
 import lcov from './lcov'
 
 class CoverageContainer {
@@ -10,7 +11,14 @@ class CoverageContainer {
   sources = new Map()
 
   async parseSource(file) {
-    this.sources.set(file, await lcov(file))
+    const [project] = atom.project.relativizePath(file)
+    const coverage = await lcov(file)
+
+    for (const fileCoverage of coverage) {
+      fileCoverage.file = path.resolve(project, fileCoverage.file)
+    }
+
+    this.sources.set(file, coverage)
   }
 
   removeSource(file) {


### PR DESCRIPTION
I recently updated to Jest 25 and discovered that the lcov report is now generating relative paths :eyes:

This simply resolves all the paths relative to the projects root, if the source file paths are absolute then nothing is changed 😁 
